### PR TITLE
Fix crashes, silent bugs, and design issues from code review

### DIFF
--- a/FIXES.md
+++ b/FIXES.md
@@ -1,0 +1,5 @@
+# Review Findings – Fix List
+
+Branch: `fixes/review-findings`
+
+All items resolved.

--- a/config.go
+++ b/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"net/http"
 )
 
@@ -12,12 +12,12 @@ type Configuration struct {
 	HTTPAddr    string `json:"addr"`       // http address and port
 	HTMLPath    string `json:"basepath"`   // html basepath
 	MQTTBroker  string `json:"broker"`     // MQTT Broker
-	VideoDevice int    `json:video-device` // Capture device
-	Image       string `json:image`        // Single image
-	Video       string `json:video`
-	CascadeFile string `json:cascade-file`
+	VideoDevice int    `json:"video-device"` // Capture device
+	Image       string `json:"image"`        // Single image
+	Video       string `json:"video"`
+	CascadeFile string `json:"cascade-file"`
 	Pipeline    string `json:"pipeline"`
-	WaitTime    int    `json"wait-time"`
+	WaitTime    int    `json:"wait-time"`
 
 	ListFilters bool `json:"list-filters"` // List filters
 
@@ -41,7 +41,7 @@ func (c *Configuration) Save(path string) (err error) {
 		return fmt.Errorf("Config Save [%s] failed json.Marshal config [%w]", path, err)
 	}
 
-	err = ioutil.WriteFile(path, buf, 0644)
+	err = os.WriteFile(path, buf, 0644)
 	if err != nil {
 		return fmt.Errorf("Config Save [%s] failed to save file: [%w]", path, err)
 	}

--- a/filters/colors.go
+++ b/filters/colors.go
@@ -25,7 +25,7 @@ func (flt *ColorDetector) Init(config string) {
 
 }
 
+// TODO: not yet implemented
 func (flt *ColorDetector) Filter(frame *redeye.Frame) *redeye.Frame {
-
 	return frame
 }

--- a/filters/pipeline.go
+++ b/filters/pipeline.go
@@ -29,12 +29,5 @@ func NewPipeline(pipestr string) *Pipeline {
 }
 
 func (p *Pipeline) Close() error {
-	for _, fltname := range p.Filters {
-		_ = fltname
-	}
 	return nil
-}
-
-type Pipe struct {
-	Filter
 }

--- a/imgout.go
+++ b/imgout.go
@@ -23,6 +23,12 @@ func NewWindow(name string) (w *Window) {
 	return w
 }
 
+func (w *Window) Close() error {
+	w.running = false
+	w.Window.Close()
+	return nil
+}
+
 func (w *Window) Play() (outQ chan *Frame) {
 	outQ = make(chan *Frame)
 	w.running = true

--- a/imgsrc.go
+++ b/imgsrc.go
@@ -80,8 +80,7 @@ func (cam *Cam) Play() chan *Frame {
 // the FrameQ channel
 func (cam *Cam) Close() error {
 	cam.running = false
-	cam.Close()
-	close(cam.frameQ)
+	cam.cap.Close()
 	return nil
 }
 
@@ -126,6 +125,7 @@ func (i *Img) Play() chan *Frame {
 	go func() {
 		time.Sleep(10 * time.Millisecond)
 		i.frameQ <- i.frame
+		i.running = false
 	}()
 	return i.frameQ
 }
@@ -191,5 +191,6 @@ func (v *VideoFile) Play() chan *Frame {
 }
 
 func (v *VideoFile) Close() error {
+	v.running = false
 	return v.VideoCapture.Close()
 }

--- a/mjpeg.go
+++ b/mjpeg.go
@@ -36,10 +36,6 @@ func (m *MJPEG) Play() chan *Frame {
 }
 
 func (m *MJPEG) Close() error {
-	if m.opened {
-
-		m.opened = false
-		return m.Close()
-	}
+	m.opened = false
 	return nil
 }

--- a/redeye/main.go
+++ b/redeye/main.go
@@ -6,6 +6,9 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
+	"sync"
+	"syscall"
 
 	"github.com/rustyeddy/redeye"
 	"github.com/rustyeddy/redeye/filters"
@@ -52,18 +55,37 @@ func main() {
 
 	startServer()
 
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		<-sigCh
+		log.Println("shutting down ...")
+		close(done)
+	}()
+
 	var outputs []chan *redeye.Frame
 	outputs = append(outputs, mjpeg.Play())
 	outputs = append(outputs, w.Play())
 
 	frameQ := imgsrc.Play()
 	for imgsrc.IsRunning() {
-		f := <-frameQ
-		for _, flt := range pipeline.Filters {
-			f = flt.Filter(f)
-		}
-		for _, outQ := range outputs {
-			outQ <- f
+		select {
+		case <-done:
+			return
+		case f := <-frameQ:
+			for _, flt := range pipeline.Filters {
+				f = flt.Filter(f)
+			}
+			var wg sync.WaitGroup
+			for _, outQ := range outputs {
+				wg.Add(1)
+				go func(ch chan *redeye.Frame) {
+					defer wg.Done()
+					ch <- f
+				}(outQ)
+			}
+			wg.Wait()
 		}
 	}
 }
@@ -84,7 +106,6 @@ func startImgSrc(config *redeye.Configuration) (imgsrc redeye.ImgSrc) {
 		log.Printf("Failed to open video device: %d - %+v", config.VideoDevice, err)
 		os.Exit(1)
 	}
-	fmt.Println("returning waitTime", config.WaitTime)
 	return imgsrc
 }
 
@@ -112,7 +133,6 @@ func startMJPEG() *redeye.MJPEG {
 }
 
 func listFilters() {
-	fmt.Println("Filters")
 	names := filters.Filters.List()
 	for _, n := range names {
 		flt, ok := filters.Filters.Get(n)


### PR DESCRIPTION
- Fix recursive Cam.Close() and MJPEG.Close() (infinite loop/stack overflow)
- Add missing Window.Close() to satisfy ImOut interface
- Fix Img.Play() staying running after single frame (main loop hang)
- Fix VideoFile.Close() not stopping reader goroutine (panic on closed channel)
- Fix malformed JSON struct tags in config.go (fields not marshaling)
- Remove debug fmt.Println from main.go
- Replace deprecated ioutil.WriteFile with os.WriteFile
- Remove dead code: Pipeline.Close() no-op loop and unused Pipe struct
- Mark ColorDetector.Filter() as a stub
- Add graceful shutdown via OS signal handling (SIGINT/SIGTERM)
- Fan-out frame dispatch to outputs concurrently with sync.WaitGroup